### PR TITLE
Replace IO (Either ...) with generic MTL classes

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,7 +2,8 @@ module Main where
 
 import Prelude (Either, IO, String, ($), (>>=), pure)
 import Control.Arrow ((|||))
-import Control.Monad.Except (ExceptT, liftEither, runExceptT)
+import Control.Monad.Except (ExceptT, MonadError, liftEither, runExceptT)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Aeson (eitherDecode)
 import Datasource.Models.Arguments (Args(..), parseArgs)
 import Datasource.DiscogsRepository (fetch)

--- a/discogs.cabal
+++ b/discogs.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 15d1459446927956da789ca824de1bb0e333302c80102c5625f280edcc54bce6
+-- hash: b689e96c3511dd7e6a9c2ce4851815e7fc5086b7018689e20f8dffe99b04b696
 
 name:           discogs
 version:        0.1.0.0
@@ -52,7 +52,7 @@ library
       src/output
       src/output/models
       src/output/transformers
-  default-extensions: DeriveAnyClass DeriveGeneric NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards TupleSections UnicodeSyntax
+  default-extensions: DefaultSignatures DeriveAnyClass DeriveGeneric FlexibleContexts GADTs NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards TupleSections UnicodeSyntax
   ghc-options: -O2 -Wincomplete-patterns
   build-depends:
       aeson
@@ -71,6 +71,7 @@ library
     , silently
     , split
     , text
+    , transformers
     , unordered-containers
     , utf8-string
     , vector
@@ -82,7 +83,7 @@ executable discogs-exe
       Paths_discogs
   hs-source-dirs:
       app
-  default-extensions: DeriveAnyClass DeriveGeneric NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards TupleSections UnicodeSyntax
+  default-extensions: DefaultSignatures DeriveAnyClass DeriveGeneric FlexibleContexts GADTs NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards TupleSections UnicodeSyntax
   ghc-options: -O2 -threaded -rtsopts -with-rtsopts=-N -Wincomplete-patterns
   build-depends:
       aeson
@@ -102,6 +103,7 @@ executable discogs-exe
     , silently
     , split
     , text
+    , transformers
     , unordered-containers
     , utf8-string
     , vector
@@ -114,7 +116,7 @@ test-suite discogs-test
       Paths_discogs
   hs-source-dirs:
       test
-  default-extensions: DeriveAnyClass DeriveGeneric NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards TupleSections UnicodeSyntax
+  default-extensions: DefaultSignatures DeriveAnyClass DeriveGeneric FlexibleContexts GADTs NamedFieldPuns NoImplicitPrelude OverloadedStrings RecordWildCards TupleSections UnicodeSyntax
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson
@@ -134,6 +136,7 @@ test-suite discogs-test
     , silently
     , split
     , text
+    , transformers
     , unordered-containers
     , utf8-string
     , vector

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ dependencies:
 - silently
 - split
 - text
+- transformers
 - unordered-containers
 - utf8-string
 - vector
@@ -53,8 +54,11 @@ library:
     - -Wincomplete-patterns
 
 default-extensions:
+- DefaultSignatures
 - DeriveAnyClass
 - DeriveGeneric
+- FlexibleContexts
+- GADTs
 - NamedFieldPuns
 - NoImplicitPrelude
 - OverloadedStrings

--- a/src/Helpers.hs
+++ b/src/Helpers.hs
@@ -34,17 +34,17 @@ quote (α:ω)    = α : (quote ω)
 wrap ∷ String → String
 wrap α = "\"" ◇ (quote α) ◇ "\""
 
-ix' ∷ String → Int → [a] → Either String a
-ix' α ω = note α . flip atMay ω
+note' ∷ MonadError String m ⇒ String → Maybe a → m a
+note' α = liftEither . note α
+
+ix' ∷ MonadError String m ⇒ String → Int → [a] → m a
+ix' α ω = note' α . flip atMay ω
 
 head' ∷ [a] → Maybe a
 head' = flip atMay 0
 
 last' ∷ [a] → Maybe a
 last' = atMay ● (pred . length)
-
-note' ∷ MonadError String m ⇒ String → Maybe a → m a
-note' α = liftEither . note α
 
 validate ∷ [a → Maybe ()] → a → Maybe a
 validate α ω = traverse (\f → f ω) α $> ω

--- a/src/Helpers.hs
+++ b/src/Helpers.hs
@@ -1,10 +1,12 @@
 module Helpers ((◁), (◀), (⊙), (●), (◇), enumerate, fork, head', 
-                iota, ix', last', putStderr, validate, wrap) where
+                iota, ix', last', note', putStderr, validate, wrap) where
 
 import Prelude (Either, Int, IO, Maybe, String, (.), (<>), flip, pred)
 import Control.Applicative (Applicative, (<*>), liftA2)
 import Control.Error.Util (note)
 import Control.Monad ((<=<))
+import Control.Monad.Except (MonadError, liftEither)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Functor (($>), (<$>), fmap)
 import Data.Ix (range)
 import Data.List (length, zip)
@@ -41,11 +43,14 @@ head' = flip atMay 0
 last' ∷ [a] → Maybe a
 last' = atMay ● (pred . length)
 
+note' ∷ MonadError String m ⇒ String → Maybe a → m a
+note' α = liftEither . note α
+
 validate ∷ [a → Maybe ()] → a → Maybe a
 validate α ω = traverse (\f → f ω) α $> ω
 
-putStderr ∷ String → IO ()
-putStderr = hPutStrLn stderr
+putStderr ∷ MonadIO m ⇒ String → m ()
+putStderr = liftIO . hPutStrLn stderr
 
 -- Digraph Tl
 f ◁ g = fmap f . g

--- a/src/datasource/models/Arguments.hs
+++ b/src/datasource/models/Arguments.hs
@@ -1,15 +1,15 @@
 module Datasource.Models.Arguments (Args(..), parseArgs) where
 
-import Prelude (Either, IO, String, (.), ($), flip, not, pure)
-import Control.Error.Util (note)
+import Prelude (Either, IO, String, (.), ($), (>>=), flip, not, pure)
 import Control.Monad (liftM4)
-import Control.Monad.Except (ExceptT(..))
+import Control.Monad.Except (MonadError)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.List (drop, elem, filter)
 import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import Data.Text (Text, pack)
 import System.Environment (getArgs)
 import Datasource.Models.Flags (Flags, makeFlags, validFlags)
-import Helpers ((◁), (⊙), ix', wrap)
+import Helpers ((◁), (⊙), ix', note', wrap)
 
 data Args = Args {
   flags ∷ Flags,
@@ -18,10 +18,10 @@ data Args = Args {
   files ∷ NonEmpty Text
 }
 
-makeFiles ∷ [String] → Either String (NonEmpty Text)
-makeFiles = note "audio files not provided" . nonEmpty . (pack . wrap) ◁ drop 2
+makeFiles ∷ MonadError String m ⇒ [String] → m (NonEmpty Text)
+makeFiles = note' "audio files not provided" . nonEmpty . (pack . wrap) ◁ drop 2
 
-makeArgs ∷ [String] → Either String Args
+makeArgs ∷ MonadError String m ⇒ [String] → m Args
 makeArgs α = liftM4 Args (pure flags) genre url files
   where flags       = makeFlags α
         allButFlags = filter (not . flip elem validFlags) α
@@ -29,5 +29,5 @@ makeArgs α = liftM4 Args (pure flags) genre url files
         url         = ix' "url not provided" 1 allButFlags
         files       = makeFiles allButFlags
 
-parseArgs ∷ ExceptT String IO Args
-parseArgs = ExceptT $ makeArgs ⊙ getArgs
+parseArgs ∷ (MonadError String m, MonadIO m) ⇒ m Args
+parseArgs = liftIO getArgs >>= makeArgs

--- a/src/output/models/Cmd.hs
+++ b/src/output/models/Cmd.hs
@@ -1,6 +1,6 @@
 module Output.Models.Cmd (Cmd(..), CmdName(..), cmd) where
 
-import Prelude (Bool(..), IO, Either(..), Show, String, (.), ($), flip, show)
+import Prelude (Bool(..), Either(..), Show, String, (.), ($), flip, show)
 import Control.Error.Util (note)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import System.Directory (findExecutable)

--- a/src/output/models/Cmd.hs
+++ b/src/output/models/Cmd.hs
@@ -2,6 +2,7 @@ module Output.Models.Cmd (Cmd(..), CmdName(..), cmd) where
 
 import Prelude (Bool(..), IO, Either(..), Show, String, (.), ($), flip, show)
 import Control.Error.Util (note)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import System.Directory (findExecutable)
 import Helpers ((◁), (⊙), (◇), fork)
 
@@ -23,7 +24,7 @@ instance Show Cmd where
     (EyeD3,  Right(ω)) → ω ◇ " "
     (_    ,  _       ) → ""
 
-cmd ∷ CmdName → IO Cmd
+cmd ∷ MonadIO m ⇒ CmdName → m Cmd
 cmd name =
   let needed  = case name of
                 Mp3Val → False
@@ -31,4 +32,4 @@ cmd name =
       find    = findExecutable $ show name
       convert = note ("Command not found: " ◇ (show name))
       make    = Cmd needed name
-  in (make ⊙ convert) ⊙ find
+  in liftIO $ (make ⊙ convert) ⊙ find

--- a/src/output/transformers/AlbumResponseTransformer.hs
+++ b/src/output/transformers/AlbumResponseTransformer.hs
@@ -3,6 +3,7 @@ module Output.Transformers.AlbumResponseTransformer (transformAlbum) where
 import Prelude (Bool, Either, String, (.), ($), (/=), (=<<), const, zipWith)
 import Control.Error.Util (note)
 import Control.Monad (join)
+import Control.Monad.Except (MonadError)
 import Control.Parallel.Strategies (parMap, rpar)
 import Data.Maybe (fromMaybe)
 import Data.List (filter)
@@ -11,7 +12,7 @@ import Data.Text (Text)
 import Datasource.Models.Flags (Flags, expand)
 import Datasource.Models.AlbumResponse (AlbumResponse(..))
 import Datasource.Models.TrackResponse (type_)
-import Helpers ((⊙), (◇), fork)
+import Helpers ((⊙), (◇), fork, note')
 import Output.Models.EyeD3Tag (EyeD3Tag(..), showCmd)
 import Output.Transformers.ArtistResponseTransformer (transformArtist, 
                                                       transformAlbumArtist)
@@ -33,7 +34,8 @@ transformTrackList ∷ Bool → [EyeD3Tag] → EyeD3Tag → AlbumResponse → [[
 transformTrackList exp constants artist = join . transform  . tracklist
   where transform   = parMap rpar (transformTracks exp constants artist)
 
-transformAlbum ∷ Flags → Text → AlbumResponse → Either String (NonEmpty Text)
+transformAlbum ∷ MonadError String m ⇒ 
+                 Flags → Text → AlbumResponse → m (NonEmpty Text)
 transformAlbum flags specifiedGenre α = makeCmdList cmds
   where β           = removeHeadings α 
         year        = transformYear β
@@ -45,4 +47,4 @@ transformAlbum flags specifiedGenre α = makeCmdList cmds
         tracks      = transformTrackList (expand flags) constants artist β
         positions   = transformPositions flags β
         cmds        = showCmd ⊙ zipWith (◇) tracks positions
-        makeCmdList = note "no EyeD3 commands generated" . nonEmpty
+        makeCmdList = note' "no EyeD3 commands generated" . nonEmpty


### PR DESCRIPTION
- Internal type change; no different behavior.
- Explicit use of `ExceptT String IO a` replaced with generic MTL classes like `MonadError String m`.
- Mostly a learning exercise, but reduces lifting within `for` comprehensions.
- More lifting done elsewhere of course, but this can be made prettier with time.